### PR TITLE
Change `cp -rp` to `cp -Rp`

### DIFF
--- a/Nukefile
+++ b/Nukefile
@@ -260,13 +260,13 @@ END)
                 ;; copy the headers
                 (SH "sudo rm -rf #{@installprefix}/include/Nu")
                 (SH "sudo mkdir -p #{@installprefix}/include/Nu")
-                (SH "sudo cp -rp objc/*.h #{@installprefix}/include/Nu")
+                (SH "sudo cp -Rp objc/*.h #{@installprefix}/include/Nu")
                 (SH "sudo rm -rf #{@installprefix}/share/libNu")
                 (SH "sudo mkdir -p #{@installprefix}/share/libNu")
-                (SH "sudo cp -rp nu/* #{@installprefix}/share/libNu"))
+                (SH "sudo cp -Rp nu/* #{@installprefix}/share/libNu"))
       (SH "sudo mkdir -p #{@installprefix}/share")
       (SH "sudo rm -rf #{@installprefix}/share/nu")
-      (SH "sudo cp -rp share/nu #{@installprefix}/share/nu")
+      (SH "sudo cp -Rp share/nu #{@installprefix}/share/nu")
       (ifDarwin
                (SH "sudo ditto examples #{@installprefix}/share/nu/examples")))
 

--- a/bootstrap
+++ b/bootstrap
@@ -333,7 +333,7 @@ echo Installing Nu shared files and examples
 
 sudo mkdir -p "${INSTALL_PREFIX}/share/nu"
 sudo rm -rf "${INSTALL_PREFIX}/share/nu"*
-sudo cp -rp "${here}/share/nu" "${INSTALL_PREFIX}/share/nu"
+sudo cp -Rp "${here}/share/nu" "${INSTALL_PREFIX}/share/nu"
 
 sudo ditto "${here}/examples" "${INSTALL_PREFIX}/share/nu/examples"
 

--- a/notes/OBSOLETE/DEBIANINSTALL
+++ b/notes/OBSOLETE/DEBIANINSTALL
@@ -70,7 +70,7 @@ git clone git://github.com/timburks/nu.git
 cd nu
 
 mkdir -p /usr/local/share/libNu
-cp -rp nu/ /usr/local/share/libNu
+cp -Rp nu/ /usr/local/share/libNu
 
 make
 ./mininush tools/nuke

--- a/notes/OBSOLETE/FREEBSDINSTALL
+++ b/notes/OBSOLETE/FREEBSDINSTALL
@@ -98,7 +98,7 @@ cd nu
 
 rm -rf /usr/local/share/libNu
 mkdir -p /usr/local/share/libNu
-cp -rp nu /usr/local/share/libNu
+cp -Rp nu /usr/local/share/libNu
 
 gmake
 ./mininush tools/nuke

--- a/notes/OBSOLETE/OPENSOLARISINSTALL
+++ b/notes/OBSOLETE/OPENSOLARISINSTALL
@@ -113,7 +113,7 @@ cd nu
 
 rm -rf /usr/local/share/libNu
 mkdir -p /usr/local/share/libNu
-cp -rp nu /usr/local/share/libNu
+cp -Rp nu /usr/local/share/libNu
 
 gmake
 ./mininush tools/nuke

--- a/tools/nuke
+++ b/tools/nuke
@@ -714,7 +714,7 @@ END)
                       (@framework_extra_install))
                   (SH "sudo mkdir -p #{FRAMEWORK_ROOT}")
                   (SH "sudo rm -rf #{FRAMEWORK_ROOT}/#{@framework}.framework")
-                  (SH "sudo cp -rp #{@framework}.framework #{FRAMEWORK_ROOT}/#{@framework}.framework"))
+                  (SH "sudo cp -Rp #{@framework}.framework #{FRAMEWORK_ROOT}/#{@framework}.framework"))
             
             (task "test" => "framework" is
                   (SH "nutest test/test_*.nu"))


### PR DESCRIPTION
According to the manpage for cp(1), the `-r` flag is implemented for
historical compatibility, but its use is highly discouraged because
it does not correctly copy special files, symbolic links, or fifo's.